### PR TITLE
OS X support

### DIFF
--- a/al.cabal
+++ b/al.cabal
@@ -60,7 +60,11 @@ library
     include-dirs:      "C:\\Program Files (x86)\\OpenAL 1.1 SDK\\include"
     extra-libraries:   OpenAL32
   else
-    pkgconfig-depends: openal
+    if os(darwin)
+      frameworks: OpenAL
+      include-dirs: "/System/Library/Frameworks/OpenAL.framework/Headers/"
+    else
+      pkgconfig-depends: openal
 
   build-tools:         c2hs >= 0.23 && < 0.26
 


### PR DESCRIPTION
Connects to the system-provided OpenAL framework to build on OS X.

I'm not quite sure why the `include-dirs` line is necessary -- I'd think referencing the framework would make the framework headers available. But without it, `c2hs` fails due to not finding `al.h`. Perhaps it is a c2hs bug?